### PR TITLE
Move storage_path to  "/data/local/costaeres"

### DIFF
--- a/daemon/config-device.toml
+++ b/daemon/config-device.toml
@@ -27,7 +27,7 @@ socket_path = "/dev/socket/b2gkiller_hints"
 hints_path = "/data/local/tmp/prochints.dat"
 
 [content_manager]
-storage_path = "/mnt/runtime/default/emulated/costaeres"
+storage_path = "/data/local/costaeres"
 metadata_cache_capacity = 250
 
 [dweb]


### PR DESCRIPTION
The path "/mnt/runtime/default/emulated/costaeres" did not get write access in GSI-13.
https://github.com/capyloon/api-daemon/issues/16